### PR TITLE
ImageUtil.java update

### DIFF
--- a/android/src/main/java/com/emekalites/react/compress/image/ImageUtil.java
+++ b/android/src/main/java/com/emekalites/react/compress/image/ImageUtil.java
@@ -27,7 +27,10 @@ public class ImageUtil {
         try {
             fileOutputStream = new FileOutputStream(destinationPath);
             // write the compressed bitmap at the destination specified by destinationPath.
-            decodeSampledBitmapFromFile(imageFile, reqWidth, reqHeight).compress(compressFormat, quality, fileOutputStream);
+            Bitmap responseBitmap = decodeSampledBitmapFromFile(imageFile, reqWidth, reqHeight);
+            if(responseBitmap != null) {
+                responseBitmap.compress(compressFormat, quality, fileOutputStream);
+            }
         } finally {
             if (fileOutputStream != null) {
                 fileOutputStream.flush();


### PR DESCRIPTION
an update for the error that occur due to the ```null``` value returned by the ```decodeSampledBitmapFromFile``` method in the ```catch``` section in ImageUtil.java